### PR TITLE
Added an extra webpack build to support ESM usage in browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "test": "jest",
     "build:types": "tsc --emitDeclarationOnly",
-    "build": "npm run build:types && webpack",
+    "build": "npm run build:types && webpack && webpack --config webpack-esm.config.js",
     "build:light": "webpack --config webpack.config.js --env name=light",
     "build:heavy": "webpack --config webpack.config.js --env name=heavy",
     "lint": "eslint 'src/**/*.ts' --fix",

--- a/webpack-esm.config.js
+++ b/webpack-esm.config.js
@@ -1,0 +1,18 @@
+const path = require('path');
+
+const defaultConfiguration = require('./webpack.config.js');
+
+module.exports = {
+  ...defaultConfiguration,
+  ...{
+    experiments: {
+      outputModule: true,
+    },
+    output: {
+      filename: '[name].esm.js', // Output bundle file name
+      path: path.resolve(__dirname, 'dist'),
+      libraryTarget: 'module',
+      globalObject: 'this',
+    },
+  },
+};


### PR DESCRIPTION
The new webpack configuration will generate a relatively clean bundle the uses generic esm exports and allows websites to use the "esm" import syntax.