### PR TITLE
fix(build): restore CommonJS-consumable type declarations (dual-package)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "default": "./dist/index.esm.js"
       },
       "require": {
-        "types": "./dist/index.d.ts",
+        "types": "./dist/cjs/index.d.ts",
         "default": "./dist/index.cjs"
       }
     }
@@ -25,7 +25,7 @@
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "build:sdk": "npx bun run src/sdk/parseSwagger.ts && npx oxlint src/sdk/swagger.ts --fix && npx bun run md/extract.ts",
-    "build:types": "tsc --emitDeclarationOnly",
+    "build:types": "tsc --emitDeclarationOnly && node scripts/emit-cjs-dts.mjs",
     "build:esm": "webpack --config webpack-esm.config.mjs",
     "build:cjs": "webpack --config webpack-cjs.config.mjs",
     "build": "npm run build:sdk && npm run build:types && npm run build:esm && npm run build:cjs",

--- a/scripts/emit-cjs-dts.mjs
+++ b/scripts/emit-cjs-dts.mjs
@@ -1,0 +1,47 @@
+// Emit a CommonJS-flavored copy of the per-file `.d.ts` tree under `dist/cjs/`.
+//
+// The package is `"type": "module"`, so every `tsc`-emitted `.d.ts` in `dist/`
+// is an ESM declaration. CommonJS consumers (e.g. Azure Functions on
+// `moduleResolution: node16`) resolve the `exports["."].require.types`
+// condition and would otherwise be handed an ESM `.d.ts` — which TypeScript
+// refuses to `require` (TS1479) and whose re-exports it cannot resolve as CJS
+// (TS2305).
+//
+// `dts-bundle-generator` (the previous fix, see git history) crashes on
+// stellar-sdk v16's `xdr.ScVal` types, so we cannot bundle. Instead we copy the
+// per-file declarations verbatim into `dist/cjs/` and drop a
+// `{"type":"commonjs"}` marker there: the nearest package.json makes Node/TS
+// interpret that whole subtree as CommonJS, so the identical declarations now
+// resolve their relative re-exports as CJS. `exports["."].require.types` points
+// at `dist/cjs/index.d.ts`; the ESM `import` condition keeps using `dist/`.
+
+import { readdirSync, mkdirSync, copyFileSync, writeFileSync, statSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+
+const DIST = 'dist'
+const CJS_DIR = join(DIST, 'cjs')
+
+function walk(dir, onFile) {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name)
+    if (full === CJS_DIR) continue // never recurse into our own output
+    if (statSync(full).isDirectory()) walk(full, onFile)
+    else onFile(full)
+  }
+}
+
+mkdirSync(CJS_DIR, { recursive: true })
+
+let copied = 0
+walk(DIST, (file) => {
+  if (!file.endsWith('.d.ts')) return
+  const rel = file.slice(DIST.length + 1) // path relative to dist/
+  const out = join(CJS_DIR, rel)
+  mkdirSync(dirname(out), { recursive: true })
+  copyFileSync(file, out)
+  copied++
+})
+
+writeFileSync(join(CJS_DIR, 'package.json'), `${JSON.stringify({ type: 'commonjs' }, null, 2)}\n`)
+
+console.log(`emit-cjs-dts: copied ${copied} .d.ts file(s) into ${CJS_DIR}/ + {"type":"commonjs"} marker`)


### PR DESCRIPTION
## Problem
`@xoxno/sdk-js` (1.0.134+) is un-type-checkable by **CommonJS** consumers on `moduleResolution: node16` — e.g. the `xoxno-az-functions` Stellar indexer. Commit `9588583` switched the type build to per-file `tsc --emitDeclarationOnly` to support stellar-sdk v16 (`dts-bundle-generator` crashes on v16's `xdr.ScVal`). But the package is `"type": "module"`, so every emitted `.d.ts` is an **ESM** declaration, and `exports["."].require.types` pointed at that ESM `index.d.ts` with no CommonJS counterpart (1.0.133 shipped a proper `index.bundled.d.cts`).

Result for CJS consumers: `TS1479` (can't `require` an ESM declaration) + `TS2305` (re-exports unresolved). **Real-world impact:** the indexer's local decoder reads `config.loanToValueBps` etc., but the SDK's broken CJS types meant the project couldn't compile against any fixed version — so production stayed on 1.0.133, whose decoder predates per-asset e-mode params and writes `ltv/liquidationThreshold/liquidationBonus = "0"` into the DB.

## Fix
Emit a CommonJS copy of the declaration tree under `dist/cjs/` with a `{"type":"commonjs"}` marker (`scripts/emit-cjs-dts.mjs`, wired into `build:types`) and point `exports["."].require.types` at `dist/cjs/index.d.ts`. The nearest `package.json` makes that subtree resolve as CommonJS, so the identical declarations resolve their re-exports correctly. **No bundler** → the v16 `xdr.ScVal` crash is avoided. The ESM `import` condition is unchanged.

## Verification
- `xoxno-az-functions` `tsc --noEmit` → **0 errors** against a packed build (was 15: TS1479/TS2305).
- `verify:dist` (CJS `require` + ESM `import` runtime smoke test) → green.
- `build:types` clean; 39 `.d.ts` mirrored into `dist/cjs/`.

## Note on release
Merging to `alpha` triggers the publish workflow (`npm version patch` → publish). This will release **1.0.142**, which carries both the per-asset e-mode decoder (already in 1.0.134+) and these working CJS types.

https://claude.ai/code/session_019AmtgSwUbrbCuKw9VWhML9