### PR TITLE
feat(stellar): oracle config read field + soroban error mapping

### DIFF
--- a/src/sdk/stellar/__tests__/lending-read.test.ts
+++ b/src/sdk/stellar/__tests__/lending-read.test.ts
@@ -1,5 +1,6 @@
 import { XOXNOClient } from '../../../utils/api'
 import {
+  getStellarAsset,
   getStellarAssets,
   getStellarHubs,
   getStellarLendingContext,
@@ -9,7 +10,7 @@ import {
   getStellarAssetMarkets,
   stellarLendingRead,
 } from '../index'
-import type { StellarReserve } from '../index'
+import type { StellarAsset, StellarReserve } from '../index'
 
 describe('stellar lending read surface', () => {
   it('re-exports the read functions from the barrel', () => {
@@ -124,5 +125,68 @@ describe('stellar lending read surface', () => {
     await read.assetMarkets('CASSET', 'deposit')
     expect(captured.path).toBe('/stellar-lending/assets/CASSET/markets')
     expect(captured.opts?.params).toEqual({ side: 'deposit' })
+  })
+
+  it('getStellarAsset parses oracle provider config', async () => {
+    const client = new XOXNOClient()
+    const assetSample: StellarAsset = {
+      asset: 'CASSET:CA...',
+      symbol: 'CASSET',
+      name: 'Custom Asset',
+      decimals: 18,
+      usdPriceWad: '1000000000000000000',
+      usdPriceShort: 1,
+      totalDepositsUsd: '1000000',
+      totalBorrowsUsd: '500000',
+      availableLiquidityUsd: '500000',
+      hubCount: 1,
+      reserveCount: 2,
+      minSupplyApy: 0.01,
+      maxSupplyApy: 0.05,
+      minBorrowApy: 0.02,
+      maxBorrowApy: 0.08,
+      oracleProvider: {
+        baseTokenId: 'base-id',
+        quoteTokenSymbol: 'USD',
+        toleranceUpperBps: 100,
+        toleranceLowerBps: 100,
+        pricingMethod: 1,
+        oracleType: 2,
+        strategy: 3,
+        assetDecimals: 18,
+        maxPriceStaleSeconds: 3600,
+        primaryProvider: 1,
+        primaryContract: 'CA...',
+        primaryAsset: 'CASSET',
+        primarySymbol: 'CASSET',
+        primaryFeedId: 'feed-1',
+        primaryQuoteToken: 'USD',
+        primaryReadMode: 1,
+        primaryTwapRecords: 5,
+        primaryDecimals: 18,
+        primaryResolutionSeconds: 300,
+        primaryMaxStaleSeconds: 3600,
+        anchorProvider: 2,
+        anchorContract: 'CA2...',
+        anchorAsset: 'CASSET2',
+        anchorSymbol: 'CASSET2',
+        anchorFeedId: 'feed-2',
+        anchorQuoteToken: 'USD',
+        anchorReadMode: 1,
+        anchorTwapRecords: 5,
+        anchorDecimals: 18,
+        anchorResolutionSeconds: 300,
+        anchorMaxStaleSeconds: 3600,
+        minSanityPriceWad: '500000000000000000',
+        maxSanityPriceWad: '2000000000000000000',
+      },
+    }
+    client.fetchWithTimeout = (async () => assetSample) as unknown as typeof client.fetchWithTimeout
+
+    const asset = await getStellarAsset(client, 'CASSET')
+    expect(asset).toBe(assetSample)
+    expect(asset.oracleProvider).toBeDefined()
+    expect(asset.oracleProvider?.baseTokenId).toBe('base-id')
+    expect(asset.oracleProvider?.quoteTokenSymbol).toBe('USD')
   })
 })

--- a/src/sdk/stellar/index.ts
+++ b/src/sdk/stellar/index.ts
@@ -18,3 +18,7 @@ export type {
   StellarStrategySwapPathInput,
   StellarStrategySwapHopInput,
 } from './scval-encode'
+
+// Soroban error mapper; re-export at the stellar subpath so consumers can
+// import from '@xoxno/sdk-js/stellar-lending' when decoding contract errors.
+export { mapSorobanError } from '../../utils/soroban-errors'

--- a/src/sdk/stellar/lending-read-types.ts
+++ b/src/sdk/stellar/lending-read-types.ts
@@ -45,6 +45,43 @@ export type StellarLendingHoldersSide = 'deposits' | 'borrows'
 // Asset
 // -----------------------------------------------------------------------------
 
+/** Oracle configuration for a Stellar asset. */
+export interface StellarAssetOracleConfig {
+  baseTokenId: string
+  quoteTokenSymbol: string
+  toleranceUpperBps: number
+  toleranceLowerBps: number
+  pricingMethod: number
+  oracleType: number
+  strategy: number
+  assetDecimals: number
+  maxPriceStaleSeconds: number
+  primaryProvider: number
+  primaryContract: string
+  primaryAsset: string | null
+  primarySymbol: string | null
+  primaryFeedId: string | null
+  primaryQuoteToken: string | null
+  primaryReadMode: number
+  primaryTwapRecords: number
+  primaryDecimals: number
+  primaryResolutionSeconds: number
+  primaryMaxStaleSeconds: number
+  anchorProvider: number | null
+  anchorContract: string | null
+  anchorAsset: string | null
+  anchorSymbol: string | null
+  anchorFeedId: string | null
+  anchorQuoteToken: string | null
+  anchorReadMode: number
+  anchorTwapRecords: number
+  anchorDecimals: number
+  anchorResolutionSeconds: number
+  anchorMaxStaleSeconds: number
+  minSanityPriceWad: string
+  maxSanityPriceWad: string
+}
+
 /** One (spoke, hub) market row for an asset's markets table. */
 export interface StellarAssetMarket {
   spokeId: number
@@ -79,6 +116,7 @@ export interface StellarAsset {
   maxSupplyApy: number
   minBorrowApy: number
   maxBorrowApy: number
+  oracleProvider?: StellarAssetOracleConfig
 }
 
 // -----------------------------------------------------------------------------

--- a/src/utils/__tests__/soroban-errors.test.ts
+++ b/src/utils/__tests__/soroban-errors.test.ts
@@ -1,0 +1,33 @@
+import { mapSorobanError } from '../soroban-errors'
+
+describe('mapSorobanError', () => {
+  it('maps a known SpokeError contract error', () => {
+    const raw = 'HostError: Error(Contract, #314)'
+    expect(mapSorobanError(raw)).toEqual({
+      code: 314,
+      name: 'SpokeCapBelowUsage',
+      message: 'The new cap is below current usage on this spoke asset.',
+    })
+  })
+
+  it('maps a known OracleError contract error', () => {
+    const raw = 'simulation failed: Error(Contract, #224)'
+    expect(mapSorobanError(raw)).toEqual({
+      code: 224,
+      name: 'InvalidSanityBounds',
+      message: 'Oracle sanity bounds are invalid (require 0 < min < max).',
+    })
+  })
+
+  it('returns null for an unmapped code', () => {
+    expect(mapSorobanError('Error(Contract, #99999)')).toBeNull()
+  })
+
+  it('returns null when there is no Error(Contract, #N) pattern', () => {
+    expect(mapSorobanError('network request failed')).toBeNull()
+  })
+
+  it('does not loose-digit-match a bare number in unrelated text', () => {
+    expect(mapSorobanError('tx fee 314 stroops too low')).toBeNull()
+  })
+})

--- a/src/utils/soroban-errors.ts
+++ b/src/utils/soroban-errors.ts
@@ -1,0 +1,55 @@
+/**
+ * rs-lending-xlm Soroban contract error codes → human-readable messages.
+ * Mirrors `common/src/errors.rs` (`GenericError`, `CollateralError`,
+ * `SpokeError`, `OracleError`). Keep in sync when that file changes.
+ */
+const SOROBAN_ERROR_CATALOG: Record<number, { name: string; message: string }> = {
+  // GenericError
+  1: { name: 'AssetNotSupported', message: 'This asset is not supported by the protocol.' },
+  2: { name: 'AssetAlreadySupported', message: 'This asset is already supported.' },
+  3: { name: 'InvalidTicker', message: 'Invalid asset ticker.' },
+  6: { name: 'InvalidAsset', message: 'Invalid asset address.' },
+  10: { name: 'InvalidPoolTemplate', message: 'The liquidity pool template hash is invalid.' },
+  11: { name: 'InvalidExchangeSrc', message: 'The oracle configuration is invalid.' },
+  12: { name: 'PairNotActive', message: 'No oracle is configured for this asset.' },
+  32: { name: 'OwnerNotSet', message: 'The contract owner has not been set.' },
+  39: { name: 'InvalidTimelockDelay', message: 'The timelock delay is out of the allowed range.' },
+  41: { name: 'InvalidRole', message: 'The caller does not hold the required role.' },
+  43: { name: 'HubNotActive', message: 'This hub is not active.' },
+  44: { name: 'NotAuthorized', message: 'The caller is not authorized to perform this action.' },
+  46: { name: 'OperationNotCancellable', message: 'This governance operation cannot be cancelled.' },
+  // CollateralError
+  113: { name: 'InvalidLiqThreshold', message: 'LTV, liquidation threshold, or bonus is out of bounds.' },
+  116: { name: 'InvalidBorrowParams', message: 'Supply or borrow cap configuration is invalid.' },
+  117: { name: 'InvalidUtilRange', message: 'Interest-rate utilization breakpoints are invalid.' },
+  132: { name: 'AssetDecimalsTooHigh', message: 'Asset decimals exceed the protocol maximum (27).' },
+  // SpokeError
+  300: { name: 'SpokeNotFound', message: 'This spoke does not exist.' },
+  301: { name: 'SpokeDeprecated', message: 'This spoke has been deprecated.' },
+  308: { name: 'AssetAlreadyInSpoke', message: 'This asset is already listed in the spoke.' },
+  309: { name: 'SpokeAssetsLimitReached', message: 'This spoke has reached its asset limit.' },
+  314: { name: 'SpokeCapBelowUsage', message: 'The new cap is below current usage on this spoke asset.' },
+  315: { name: 'SpokeAssetPaused', message: 'This spoke asset is paused.' },
+  316: { name: 'SpokeAssetFrozen', message: 'This spoke asset is frozen.' },
+  // OracleError
+  220: { name: 'InvalidOracleBase', message: 'The oracle quote asset/market is missing or invalid.' },
+  221: { name: 'InvalidOracleDecimals', message: 'The oracle decimals value is invalid.' },
+  224: { name: 'InvalidSanityBounds', message: 'Oracle sanity bounds are invalid (require 0 < min < max).' },
+  225: { name: 'OracleCycleDetected', message: 'A cycle was detected in the oracle quote chain.' },
+}
+
+/**
+ * Extracts a `Error(Contract, #N)` code from a raw Soroban simulation/RPC error
+ * string and resolves it against the rs-lending-xlm catalog. Matches only the
+ * exact `Error(Contract, #N)` pattern — never loose digits, since raw error
+ * strings can contain unrelated numbers (fees, ledgers, sequence numbers).
+ */
+export function mapSorobanError(
+  raw: string
+): { code: number; name: string; message: string } | null {
+  const match = raw.match(/Error\(Contract,\s*#(\d+)\)/)
+  if (!match) return null
+  const code = Number(match[1])
+  const entry = SOROBAN_ERROR_CATALOG[code]
+  return entry ? { code, ...entry } : null
+}


### PR DESCRIPTION
## Summary
- Adds `oracleProvider?: StellarAssetOracleConfig` to the `StellarAsset` detail read type (`lending-read-types.ts`), mirroring the field already surfaced by the API in xoxno-api-v2.
- Adds `soroban-errors.ts`: a catalog + `mapSorobanError()` mapping rs-lending-xlm contract error codes to human-readable messages, re-exported from `sdk/stellar/index.ts` for `@xoxno/sdk-js/stellar-lending` consumers.
- Extends `lending-read.test.ts` and adds `soroban-errors.test.ts`.

Built for the new Stellar lending admin dashboard in xoxno-ui (`/defi/admin/stellar`), which reads oracle config for display. No propose/execute builders were added or changed — all governance transaction builders already existed and are untouched.

## Test plan
- [x] Full suite: `node --experimental-vm-modules node_modules/jest/bin/jest.js` — 227/227 passing, 10/10 suites
- [x] Rebased onto latest `alpha` (`1.0.182`), tests re-run clean after rebase